### PR TITLE
Change method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # About
 
-This is an Omni Automation plug-in bundle for OmniFocus that allows the user to 'defer' all of the tasks associated with a tag. Further details are provided below.
+This is an Omni Automation plug-in bundle for OmniFocus that allows the user to 'defer' a tag and mark tags as on hold or available on a schedule. Further details are provided below.
 
 _Please note that all scripts on my GitHub account (or shared elsewhere) are works in progress. If you encounter any issues or have any suggestions please let me know--and do please make sure you backup your database before running scripts from a random amateur on the internet!_
 
@@ -16,12 +16,38 @@ None so far! 🤞
 2. Unzip the downloaded file.
 3. Move the `.omnijs` file to your OmniFocus plug-in library folder.
 
+## 'Scheduler' Tasks
+
+For the purposes of this plugin, a scheduled tag status change is represented by a 'scheduler' task with the following attributes:
+* Name starts with `AVAILABLE` or `DEFERRED`. (What follows is ignored by the script; I suggest using something meaningful to you e.g. `AVAILABLE from Saturday 1pm`).
+* Project is the first match for `Tag Scheduling` in the database.
+* Tag is the tag to be scheduled.
+* Defer date is the time that the tag should become available or be placed on hold.
+
+These scheduler tasks can be created manually by the user (recommended for more complicated instances e.g. store opening hours which repeat on a weekly basis) or a single tag can be deferred to a specific date and time by using the `Defer Tasks With Tag` action.
+
+Suggestions:
+* For repeating scheduler tasks ensure that `Assigned Dates` are used to maintain the same times.
+* For manually created scheduler tasks you will likely want to ensure that there are no notifications set to trigger on the defer date - you probably don't want to see these!
+
 # Actions
 
 ## Defer Tasks With Tag
 
 This action shows a form prompting the user to select a tag and enter a defer date. 
 
-Then, for each task with the selected tag or any subtags of the selected tag, it checks the defer date and:
-1. If the existing defer date is after the entered defer date, no change is made.
-2. Otherwise, the task's defer date is set to the entered date.
+Then, for each task with the selected tag or any subtags of the selected tag, it creates a 'scheduler' task as described above.
+
+## Updated Timed Tags
+
+This action runs the `updateTimedTags` function described below.
+
+# Functions
+
+This plugin contains the following functions within the `deferTagLib` library:
+
+## updateTimedTags
+
+This function checks for any uncompleted 'scheduler' tasks with defer dates before the current time and updates relevant tag statuses accordingly (from oldest defer date to newest). It then marks these scheduler task as complete.
+
+This function can be run manually using the `Update Timed Tags` action but can also be scheduled to run at regular intervals using external tools e.g. Keyboard Maestro.

--- a/Resources/deferTagLib.js
+++ b/Resources/deferTagLib.js
@@ -1,0 +1,35 @@
+(() => {
+  let deferTagLib = new PlugIn.Library(new Version("1.0"));
+
+  deferTagLib.updateTimedTags = () => {
+    cleanUp();
+
+    let now = new Date();
+
+    // get all uncompleted scheduler tasks whose defer date has passed
+    let schedulers = projectsMatching("Tag Scheduling")[0].tasks.filter(
+      (task) =>
+        task.deferDate < now && task.taskStatus !== Task.Status.Completed
+    );
+
+    // sort scheduler tasks - earliest defer date first
+    schedulers.sort((a, b) => (a.deferDate < b.deferDate ? -1 : 1));
+
+    // for each scheduler task...
+    schedulers.forEach((scheduler) => {
+      // make tag active or on hold as required
+      let tag = scheduler.tags[0];
+      if (scheduler.name.startsWith("AVAILABLE")) {
+        tag.status = Tag.Status.Active;
+      } else if (scheduler.name.startsWith("DEFERRED")) {
+        tag.status = Tag.Status.OnHold;
+      }
+
+      // and then mark complete
+      scheduler.markComplete();
+    });
+  };
+
+
+  return deferTagLib;
+})();

--- a/Resources/deferTasksWithTag.js
+++ b/Resources/deferTasksWithTag.js
@@ -1,6 +1,6 @@
 (() => {
   var action = new PlugIn.Action(function (selection, sender) {
-    showForm(); // once form has been completed, deferTasks(tag, date) is called
+    showForm(); // once form has been completed, deferTag(tag, date) is called
   });
 
   action.validate = function (selection, sender) {
@@ -48,7 +48,7 @@ function showForm() {
 
   // process using form data
   formPromise.then(function (formObject) {
-    deferTasks(formObject.values["menuItem"], formObject.values["dateInput"]);
+    deferTag(formObject.values["menuItem"], formObject.values["dateInput"]);
   });
 
   // promise function called when form cancelled
@@ -57,12 +57,19 @@ function showForm() {
   });
 }
 
-function deferTasks(tag, date) {
-  tag.apply((tag) => {
-    tag.tasks.forEach((task) => {
-      if (date > task.deferDate) {
-        task.deferDate = date;
-      }
-    });
+function deferTag(tag, date) {
+  let scheduler = new Task(
+    `AVAILABLE @ ${date}`,
+    projectsMatching("Tag Scheduling")[0]
+  );
+  scheduler.addTag(tag);
+  scheduler.deferDate = date;
+
+  // make sure there are no notifications
+  scheduler.notifications.forEach((notification) => {
+    scheduler.removeNotification(notification);
   });
+
+  // update tag status
+  tag.status = Tag.Status.OnHold;
 }

--- a/Resources/deferTasksWithTag.js
+++ b/Resources/deferTasksWithTag.js
@@ -19,7 +19,9 @@ function showForm() {
     "menuItem",
     "Tag To Defer",
     flattenedTags,
-    null,
+    flattenedTags.map((tag) => {
+      return tag.name;
+    }),
     null
   );
 

--- a/Resources/en.lproj/deferTasksWithTag.strings
+++ b/Resources/en.lproj/deferTasksWithTag.strings
@@ -1,4 +1,4 @@
-"label" = "Defer Tasks With Tag";
-"shortLabel" = "Defer Tasks With Tag";
-"mediumLabel" = "Defer Tasks With Tag";
-"longLabel" = "Defer Tasks With Tag";
+"label" = "Defer Tag";
+"shortLabel" = "Defer Tag";
+"mediumLabel" = "Defer Tag";
+"longLabel" = "Defer Tag";

--- a/Resources/en.lproj/updateTimedTags.strings
+++ b/Resources/en.lproj/updateTimedTags.strings
@@ -1,0 +1,4 @@
+"label" = "Update Timed Tags";
+"shortLabel" = "Update Timed Tags";
+"mediumLabel" = "Update Timed Tags";
+"longLabel" = "Update Timed Tags";

--- a/Resources/updateTimedTags.js
+++ b/Resources/updateTimedTags.js
@@ -1,0 +1,12 @@
+(() => {
+  let action = new PlugIn.Action(function (selection, sender) {
+    this.deferTagLib.updateTimedTags();
+  });
+
+  action.validate = function (selection, sender) {
+    // only valid if nothing is selected - so does not show in share menu
+    return selection.tasks.length == 0 && selection.projects.length == 0;
+  };
+
+  return action;
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,9 @@
   "author": "Kaitlin Salzke",
   "description": "'Defer' a tag",
   "version": "1.0.0",
-  "actions": [{ "identifier": "deferTasksWithTag" }],
-  "libraries": []
+  "actions": [
+    { "identifier": "deferTasksWithTag" },
+    { "identifier": "updateTimedTags" }
+  ],
+  "libraries": [{ "identifier": "deferTagLib" }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "identifier": "com.KaitlinSalzke.deferTag",
   "author": "Kaitlin Salzke",
   "description": "'Defer' a tag",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "actions": [
     { "identifier": "deferTasksWithTag" },
     { "identifier": "updateTimedTags" }


### PR DESCRIPTION
Refer update README - this change updates the way that tags are deferred: instead of looking at all tasks with a specific tag (which could cause issues with repeating tasks and did not apply to any tasks tagged initially), the tag itself is now put on hold or made available with the use of 'scheduler' tasks. This also allows for flexibility with repeating tasks for e.g. store opening hours.